### PR TITLE
Make WireMockAware a trait instead of a subclass

### DIFF
--- a/src/Context/Initializer/WiremockAwareInitializer.php
+++ b/src/Context/Initializer/WiremockAwareInitializer.php
@@ -6,7 +6,7 @@ namespace VPX\WiremockExtension\Context\Initializer;
 
 use Behat\Behat\Context\Context as ContextInterface;
 use Behat\Behat\Context\Initializer\ContextInitializer;
-use VPX\WiremockExtension\Context\WiremockAwareContextInterface;
+use VPX\WiremockExtension\Context\WiremockAwareInterface;
 use VPX\WiremockExtension\Context\WiremockContext;
 use WireMock\Client\WireMock;
 
@@ -39,7 +39,7 @@ class WiremockAwareInitializer implements ContextInitializer
      */
     public function initializeContext(ContextInterface $context)
     {
-        if ($context instanceof WiremockAwareContextInterface) {
+        if ($context instanceof WiremockAwareInterface) {
             $context->setWiremock($this->wiremock);
         }
         if ($context instanceof WiremockContext) {

--- a/src/Context/WiremockAware.php
+++ b/src/Context/WiremockAware.php
@@ -6,7 +6,7 @@ namespace VPX\WiremockExtension\Context;
 
 use WireMock\Client\WireMock;
 
-class WiremockAwareContext implements WiremockAwareContextInterface
+trait WiremockAware
 {
     /**
      * @var \WireMock\Client\WireMock

--- a/src/Context/WiremockAwareInterface.php
+++ b/src/Context/WiremockAwareInterface.php
@@ -6,7 +6,7 @@ namespace VPX\WiremockExtension\Context;
 
 use WireMock\Client\WireMock;
 
-interface WiremockAwareContextInterface
+interface WiremockAwareInterface
 {
     public function setWiremock(WireMock $wiremock);
 

--- a/src/Context/WiremockContext.php
+++ b/src/Context/WiremockContext.php
@@ -13,8 +13,9 @@ use WireMock\Client\MappingBuilder;
 use WireMock\Stubbing\StubImportBuilder;
 use WireMock\Stubbing\StubMapping;
 
-class WiremockContext extends WiremockAwareContext implements ContextInterface
+class WiremockContext implements WiremockAwareInterface, ContextInterface
 {
+    use WiremockAware;
 
     /**
      * @var string


### PR DESCRIPTION
PHP only allows a single parent class. Using it as a trai makes it 
easier to use with other extensions.

This follows similar patterns used by PSR3 logger etc.